### PR TITLE
Add xcassets to framework for Carthage

### DIFF
--- a/BreadCrumb Control.xcodeproj/project.pbxproj
+++ b/BreadCrumb Control.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2B3E70251F4EAD5B003ABE51 /* BreadCrumbControl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B3E700F1F4EAD5A003ABE51 /* BreadCrumbControl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2B3E702D1F4EAD9A003ABE51 /* BreadCrumb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01F2E861C0268F500967FDA /* BreadCrumb.swift */; };
 		2B3E702E1F4EAD9D003ABE51 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01F2E871C0268F500967FDA /* CustomButton.swift */; };
+		2B3E70331F4ED6B9003ABE51 /* BreadCrumb.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73A694761E2C8936005B5F3B /* BreadCrumb.xcassets */; };
 		73A694771E2C8936005B5F3B /* BreadCrumb.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73A694761E2C8936005B5F3B /* BreadCrumb.xcassets */; };
 		D01F2E551C02667900967FDA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01F2E541C02667900967FDA /* AppDelegate.swift */; };
 		D01F2E571C02667900967FDA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01F2E561C02667900967FDA /* ViewController.swift */; };
@@ -338,6 +339,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B3E70331F4ED6B9003ABE51 /* BreadCrumb.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Don't worry. I forgot add xcassets into framework for Carthage at https://github.com/apparition47/BreadCrumbControl/pull/2
I fixed it.