### PR TITLE
Make `BreadCrumbControlDelegate` public

### DIFF
--- a/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
+++ b/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
@@ -12,12 +12,12 @@ public enum StyleBreadCrumb {
     case gradientFlatStyle
 }
 
-protocol BreadCrumbControlDelegate: class {
+public protocol BreadCrumbControlDelegate: class {
     func didTouchItem(index: Int, item: String)
     func didTouchRootButton()
 }
 
-extension BreadCrumbControlDelegate {
+public extension BreadCrumbControlDelegate {
     func didTouchItem(index: Int, item: String) {}
     func didTouchRootButton() {}
 }


### PR DESCRIPTION
I forgot to make `BreadCrumbControlDelegate` public, when I create `BreadCrumbControlDelegate`.