### PR TITLE
Disable last arrow when flat style #7

### DIFF
--- a/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
+++ b/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
@@ -397,6 +397,14 @@ public class CBreadcrumbControl: UIScrollView {
             }
             let label = itemsEvolution[0].itemLabel
             let itemButton = self.itemButton( item: label, position: _itemViews.count)
+            if itemsEvolutionToSend.count == 0 {
+                itemButton.isLast = true
+            }
+            if _itemViews.count >= 1 {
+                if let button = _itemViews[_itemViews.count-1] as? BreadCrumbButton {
+                    button.isLast = false
+                }
+            }
             let widthButton = itemButton.frame.size.width
             startPosition = (_itemViews.count > 0) ? endPosition - widthButton - kBreadcrumbCover : endPosition - widthButton
             var rectUIButton = itemButton.frame
@@ -490,6 +498,11 @@ public class CBreadcrumbControl: UIScrollView {
                     this._itemViews.removeLast()
                     this._items.removeLast()
 
+                    if this._itemViews.count >= 1 {
+                        if let button = this._itemViews[this._itemViews.count-1] as? BreadCrumbButton {
+                            button.isLast = true
+                        }
+                    }
                     
                     if itemsEvolutionToSend.count == 0 {
                         let contentWidth = this._itemViews.reduce(kBreadcrumbCover) { (width, button) in
@@ -517,6 +530,12 @@ public class CBreadcrumbControl: UIScrollView {
                 lastViewShowing.removeFromSuperview()
                 self._itemViews.removeLast()
                 self._items.removeLast()
+                
+                if _itemViews.count >= 1 {
+                    if let button = _itemViews[_itemViews.count-1] as? BreadCrumbButton {
+                        button.isLast = true
+                    }
+                }
                 
                 if itemsEvolutionToSend.count == 0 {
                     let contentWidth = self._itemViews.reduce(kBreadcrumbCover) { (width, button) in

--- a/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
+++ b/BreadCrumb Control/BreadCrumb Control/BreadCrumb.swift
@@ -382,7 +382,7 @@ public class CBreadcrumbControl: UIScrollView {
         context.evolutions.remove(at: 0)
         
         let frame = self.frame
-        let enabledAnimation = !refresh && (self.animationSpeed > 1e-15)
+        let enabledAnimation = !refresh && (self.animationSpeed > 0)
 
         if currentEvolution.operationItem == .add {
             //create a new UIButton
@@ -416,8 +416,7 @@ public class CBreadcrumbControl: UIScrollView {
             context.items.append( label)
 
             if enabledAnimation {
-                UIView.animate( withDuration: self.animationSpeed, delay: 0, options:[.curveEaseInOut], animations: { [weak self] in
-                    guard let this = self else { return }
+                UIView.animate( withDuration: self.animationSpeed, delay: 0, options:[.curveEaseInOut], animations: {
                     CBreadcrumbControl.addOffset(to: itemButton, offsetX: endPosition)
                 }, completion: { [weak self] finished in
                     guard let this = self else { return }
@@ -480,8 +479,7 @@ public class CBreadcrumbControl: UIScrollView {
             lastViewShowing.frame = rectUIButton
             
             if enabledAnimation {
-                UIView.animate( withDuration: self.animationSpeed, delay: 0, options:[.curveEaseInOut], animations: { [weak self] in
-                    guard let this = self else { return }
+                UIView.animate( withDuration: self.animationSpeed, delay: 0, options:[.curveEaseInOut], animations: {
                     CBreadcrumbControl.addOffset(to: lastViewShowing, offsetX: endPosition)
                 }, completion: { [weak self] finished in
                     guard let this = self else { return }

--- a/BreadCrumb Control/BreadCrumb Control/CustomButton.swift
+++ b/BreadCrumb Control/BreadCrumb Control/CustomButton.swift
@@ -44,6 +44,12 @@ open class BreadCrumbButton: UIButton {
         }
     }
     
+    public var isLast: Bool = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.
     override open func draw(_ frame: CGRect)
@@ -68,19 +74,22 @@ open class BreadCrumbButton: UIButton {
             self.backgroundCustomColor.setFill()
             rectanglePath.fill()
             
-            //// Bezier 2 Drawing
-            let bezier2Path = UIBezierPath()
-            //bezier2Path.moveToPoint(CGPointMake(frame.minX + 0.95000 * frame.width, frame.minY + 5))
-            //bezier2Path.addLineToPoint(CGPointMake(frame.maxX-2, frame.minY + 0.50000 * frame.height))
-            //bezier2Path.addLineToPoint(CGPointMake(frame.minX + 0.95000 * frame.width, frame.maxY - 5))
-            bezier2Path.move(to: CGPoint(x: frame.maxX - 11 , y: frame.minY + 8))
-            bezier2Path.addLine(to: CGPoint(x: frame.maxX - 2, y: frame.minY + 0.50000 * frame.height))
-            bezier2Path.addLine(to: CGPoint(x: frame.maxX - 11, y: frame.maxY - 8))
-            bezier2Path.lineCapStyle = .round;
-            
-            self.arrowColor.setStroke()
-            bezier2Path.lineWidth = 2
-            bezier2Path.stroke()
+            // Last button's ">" is unnecessary.
+            if !isLast {
+                //// Bezier 2 Drawing
+                let bezier2Path = UIBezierPath()
+                //bezier2Path.moveToPoint(CGPointMake(frame.minX + 0.95000 * frame.width, frame.minY + 5))
+                //bezier2Path.addLineToPoint(CGPointMake(frame.maxX-2, frame.minY + 0.50000 * frame.height))
+                //bezier2Path.addLineToPoint(CGPointMake(frame.minX + 0.95000 * frame.width, frame.maxY - 5))
+                bezier2Path.move(to: CGPoint(x: frame.maxX - 11 , y: frame.minY + 8))
+                bezier2Path.addLine(to: CGPoint(x: frame.maxX - 2, y: frame.minY + 0.50000 * frame.height))
+                bezier2Path.addLine(to: CGPoint(x: frame.maxX - 11, y: frame.maxY - 8))
+                bezier2Path.lineCapStyle = .round;
+                
+                self.arrowColor.setStroke()
+                bezier2Path.lineWidth = 2
+                bezier2Path.stroke()
+            }
         }
     }
 }


### PR DESCRIPTION
<img width="248" alt="disabled_arrow_flatstyle" src="https://user-images.githubusercontent.com/25785565/30360934-4789e894-988f-11e7-881b-d69605213b98.png">

Removed last arrow in `flatStyle` case.

@apparition47 
In `flatStyle` case, I think last arrow is unnecessary. So, I don't provide an option. What do you think?