### PR TITLE
Disabled code coverage to support Xcode9 with Carthage #22

### DIFF
--- a/BreadCrumb Control.xcodeproj/project.pbxproj
+++ b/BreadCrumb Control.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				INFOPLIST_FILE = "BreadCrumb Control/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -610,6 +611,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_CODE_COVERAGE = NO;
 				INFOPLIST_FILE = "BreadCrumb Control/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
If you use BreadCrumbControl from Carthage on Xcode9, you'll see "Invalid Bundle" when you upload IPA to iTunes Connect.
https://github.com/Carthage/Carthage/issues/2056